### PR TITLE
F: delete map functionality

### DIFF
--- a/client/src/models/constants.js
+++ b/client/src/models/constants.js
@@ -1,7 +1,7 @@
 const constants = {
   api: `http://${window.location.hostname}:8081/api`,
-  //template: `http://webstrates.ucsd.edu/master`,
-  template: `https://webstrates.ucsd.edu/rikudougorin-kurikaratenshou`, // Xavier_dev
+  template: `http://webstrates.ucsd.edu/master`,
+//  template: `https://webstrates.ucsd.edu/rikudougorin-kurikaratenshou`, // Xavier_dev
   noteTemplate: `https://webstrates.ucsd.edu/sarasvati-melt-out`,
   host: 'https://webstrates.ucsd.edu/',
   baseWebstrateID: 'master'

--- a/client/src/models/constants.js
+++ b/client/src/models/constants.js
@@ -3,6 +3,7 @@ const constants = {
   template: `http://webstrates.ucsd.edu/master`,
 //  template: `https://webstrates.ucsd.edu/rikudougorin-kurikaratenshou`, // Xavier_dev
   noteTemplate: `https://webstrates.ucsd.edu/sarasvati-melt-out`,
+  invalidNoteTemplate: `https://webstrates.ucsd.edu/shuten-doujin/`,
   host: 'https://webstrates.ucsd.edu/',
   baseWebstrateID: 'master'
 }

--- a/client/src/states/modules/map.js
+++ b/client/src/states/modules/map.js
@@ -89,8 +89,6 @@ const actions = {
   },
   async retractPermission (context, {index, url}) {
     context.commit('deletePermission', index)
-    console.log("in retractPermission")
-    console.log(url)
     //Request server to change visibility
     Axios
       .post(`${constants.api}/invisibleMap`, {

--- a/client/src/states/modules/map.js
+++ b/client/src/states/modules/map.js
@@ -22,10 +22,12 @@ const mutations = {
     
     state.currentMap = new Map(time, newAddr)   
     state.maps.unshift(state.currentMap)
+    state.note = new Note('Invalid Note', `${constants.invalidNoteTemplate}`)
   },
   navigateCurrentMap (state, reqIndex) {
     state.currentMap = state.maps[reqIndex]
     state.currentMapIndex = reqIndex
+    state.note = new Note('Invalid Note', `${constants.invalidNoteTemplate}`)
   },
   syncMaps (state, mapRes) {
     if (mapRes) state.maps = mapRes.map((map) => new Map(map.name, map.url))

--- a/client/src/states/modules/map.js
+++ b/client/src/states/modules/map.js
@@ -35,6 +35,10 @@ const mutations = {
   },
   updateTitle (state, newTitle) {
     state.currentMap.title = newTitle
+  },
+  deletePermission (state, reqIndex) {
+    state.maps[reqIndex].permission = 'DELETED';
+    state.currentMap = state.maps[reqIndex];
   }
 }
 
@@ -82,6 +86,19 @@ const actions = {
   async navigateToMap (context, {index}) {
     context.commit('navigateCurrentMap', index)
     router.push('map')
+  },
+  async retractPermission (context, {index, url}) {
+    context.commit('deletePermission', index)
+    console.log("in retractPermission")
+    console.log(url)
+    //Request server to change visibility
+    Axios
+      .post(`${constants.api}/invisibleMap`, {
+        'url': url
+      })
+      .catch(function (error) {
+        bugsnagClient.notify(error)
+      })
   },
   syncMaps (context, maps) {
     context.commit('syncMaps', maps)

--- a/client/src/views/components/mapCard.vue
+++ b/client/src/views/components/mapCard.vue
@@ -1,24 +1,18 @@
 <template>
   <div class="cards">
-    <div class="map_card" v-on:click="navigaToMap">
-      <h1>Title: {{title}}</h1>
-      <div class="map_pic">
+    <div class="map_card" v-on:mouseover="toggleDeleteBtn" v-on:mouseout="toggleDeleteBtn">
+      <h1 v-on:click="navigaToMap">Title: {{title}}</h1>
+      <div class="map_pic" v-on:click="navigaToMap">
         <img src="../../asset/screen1.png">
       </div>
+      <div class="deletion" v-show="delete_mode">
+        <v-layout align-center justify-center>
+          <v-flex xs6 md6 sm6 text-xs-center text-md-center text-sm-center>
+            <v-btn class="raised delete_btn" v-on:click="deleteMap"> Delete Map </v-btn>
+          </v-flex>
+        </v-layout>
+      </div>
     </div>
-    <button class="delete_btn">
-      <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-      <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-         viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
-      <path style="fill:#E04F5F;" d="M496.158,248.085c0-137.021-111.07-248.082-248.076-248.082C111.07,0.003,0,111.063,0,248.085
-        c0,137.002,111.07,248.07,248.082,248.07C385.088,496.155,496.158,385.087,496.158,248.085z"/>
-      <path style="fill:#FFFFFF;" d="M277.042,248.082l72.528-84.196c7.91-9.182,6.876-23.041-2.31-30.951
-        c-9.172-7.904-23.032-6.876-30.947,2.306l-68.236,79.212l-68.229-79.212c-7.91-9.188-21.771-10.216-30.954-2.306
-        c-9.186,7.91-10.214,21.77-2.304,30.951l72.522,84.196l-72.522,84.192c-7.91,9.182-6.882,23.041,2.304,30.951
-        c4.143,3.569,9.241,5.318,14.316,5.318c6.161,0,12.294-2.586,16.638-7.624l68.229-79.212l68.236,79.212
-        c4.338,5.041,10.47,7.624,16.637,7.624c5.069,0,10.168-1.749,14.311-5.318c9.186-7.91,10.22-21.77,2.31-30.951L277.042,248.082z"/>
-      </svg>
-    </button>
   </div>
 </template>
 
@@ -38,6 +32,23 @@ export default {
       this.$store.dispatch("map/navigateToMap", {
         index: self.index
       });
+    },
+    toggleDeleteBtn: function() {
+      let self = this;
+      this.delete_mode = !(this.delete_mode);
+    },
+    deleteMap: function() {
+      let self = this;
+      let option = confirm("Do you really want to delete this map?\nThis action cannot be undone later.");
+      if (option == true) {
+        this.$store.dispatch("map/retractPermission", {
+          index: self.index,
+          url: self.url
+        });
+        alert("Map Deletion Confirmed!")
+      } else {
+        alert("Map Deletion Canceled!")
+      }
     }
   },
   props: ['title','url', 'index']
@@ -76,22 +87,26 @@ export default {
   .map_card:hover{
     opacity: 0.7;
   }
+  .map_pic {
+    height: 72%;
+  }
   .map_pic img{
     min-width: 420px;
     width: 100%;
-    height: 100%;
+    height: 120%;
     padding-left: 15%;
     overflow: hidden;
   }
   input{
     width: 100%;
   }
-  .delete_btn{
-    margin-bottom: -20vh;
-    z-index: 1;
+  .delete_btn {
+    background-color:  red;
+    color: whitesmoke;
+    font-size: 2.5vh;
   }
-  .delete_btn svg{
-    margin-bottom: -20vh;
+  .delete_btn .btn__content {
+    padding-bottom: 0.5em;
   }
 
 </style>

--- a/client/src/views/components/mapCard.vue
+++ b/client/src/views/components/mapCard.vue
@@ -4,25 +4,21 @@
       <h1>Title: {{title}}</h1>
       <div class="map_pic">
         <img src="../../asset/screen1.png">
-  <!--<v-card>
-    <v-card-media
-      class="white--text"
-      height="200px"
-      src="https://vuetifyjs.com/static/doc-images/cards/docks.jpg"
-    >
-      <v-container fill-height fluid>
-        <v-layout fill-height>
-          <v-flex xs12 align-end flexbox>
-            <span class="headline">{{title}}</span>
-          </v-flex>
-        </v-layout>
-      </v-container>
-    </v-card-media>
-    <v-card-title>
-      <div> 
-        <label class="grey--text">Number 10</label><br> -->
       </div>
     </div>
+    <button class="delete_btn">
+      <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+      <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+         viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+      <path style="fill:#E04F5F;" d="M496.158,248.085c0-137.021-111.07-248.082-248.076-248.082C111.07,0.003,0,111.063,0,248.085
+        c0,137.002,111.07,248.07,248.082,248.07C385.088,496.155,496.158,385.087,496.158,248.085z"/>
+      <path style="fill:#FFFFFF;" d="M277.042,248.082l72.528-84.196c7.91-9.182,6.876-23.041-2.31-30.951
+        c-9.172-7.904-23.032-6.876-30.947,2.306l-68.236,79.212l-68.229-79.212c-7.91-9.188-21.771-10.216-30.954-2.306
+        c-9.186,7.91-10.214,21.77-2.304,30.951l72.522,84.196l-72.522,84.192c-7.91,9.182-6.882,23.041,2.304,30.951
+        c4.143,3.569,9.241,5.318,14.316,5.318c6.161,0,12.294-2.586,16.638-7.624l68.229-79.212l68.236,79.212
+        c4.338,5.041,10.47,7.624,16.637,7.624c5.069,0,10.168-1.749,14.311-5.318c9.186-7.91,10.22-21.77,2.31-30.951L277.042,248.082z"/>
+      </svg>
+    </button>
   </div>
 </template>
 
@@ -31,6 +27,7 @@ export default {
   name: 'mapCard',
   data() {
     return {
+      delete_mode: false
     }
   },
   computed: {
@@ -88,6 +85,13 @@ export default {
   }
   input{
     width: 100%;
+  }
+  .delete_btn{
+    margin-bottom: -20vh;
+    z-index: 1;
+  }
+  .delete_btn svg{
+    margin-bottom: -20vh;
   }
 
 </style>

--- a/client/src/views/components/mapCollection.vue
+++ b/client/src/views/components/mapCollection.vue
@@ -3,7 +3,7 @@
     <div :class="$style.newMapInCollection">
       <new-map-card></new-map-card>
     </div>
-    <div v-for="(map, index) in maps" :class="$style.existingMapInCollection">
+    <div v-for="(map, index) in maps" v-if="map.permission=='EDIT'" :class="$style.existingMapInCollection">
       <map-card v-bind:title=map.title v-bind:url=map.url v-bind:index=index></map-card>
     </div>
   </div>

--- a/server/ContainerAPI/app/api/map.js
+++ b/server/ContainerAPI/app/api/map.js
@@ -41,10 +41,25 @@ api.createMap = (req, res) => {
 }
 
 api.updateMapTitle = (req, res) => {
-  
   // Find and update user maps
   models.Map.findOneAndUpdate({'url' : req.body.url}, 
                               { $set : {'name' : req.body.newName}},
+                            function(err, map) {
+                              if (err || map == null) {
+                                console.log(err);
+                                res.status(501).send(err);
+                                return;
+                              }
+                              console.log(map); // with original name
+                              res.status(201).send();
+  });
+  
+}
+
+api.invisibleMap = (req, res) => {
+  // Find and update user maps
+  models.Map.findOneAndUpdate({'url' : req.body.url}, 
+                              { $set : {'visibility' : 0}},
                             function(err, map) {
                               if (err || map == null) {
                                 console.log(err);

--- a/server/ContainerAPI/app/api/user.js
+++ b/server/ContainerAPI/app/api/user.js
@@ -17,7 +17,8 @@ api.syncUser = (req, res) => {
             models.Map.find({
                 '_id': { $in: mapIds}
             }, (err, maps) => {
-                mapProp = maps
+                // No longer put deleted map (visibility == 0) in res
+                mapProp = maps.filter(map => map.visibility !== 0)
             })
             .then(function() {
                 response = {

--- a/server/ContainerAPI/app/routes/map.js
+++ b/server/ContainerAPI/app/routes/map.js
@@ -10,4 +10,9 @@ module.exports = (app) => {
        .post ((req, res) => {
             api.updateMapTitle(req, res);
        });
+  
+    app.route('/api/invisibleMap')
+       .post ((req, res) => {
+            api.invisibleMap(req, res);
+       });
 }


### PR DESCRIPTION
Functionality:
User is now able to delete map. delete map is a shallow delete on server side (visibility set to 0).
User Interaction:
User hover over a mapCard => Delete button appears => User clicks delete button => Browser Confirms Deletion => User Select OK/Cancel => Browser Alerts Deletion Completed/Canceled
Data Flow:
Client Side: permission of the deleted map set to "DELETED", request server side to set the map as "invisible", and map management page no longer renders the associated mapCards.
Server Side: Set the visibility of the map in MongoDB as 0. When SyncUser is requested next time, the maps are filtered with (visibility !== 0) when forming response.
